### PR TITLE
Integrate Google login with backend

### DIFF
--- a/src/app/auth-google.service.ts
+++ b/src/app/auth-google.service.ts
@@ -56,4 +56,9 @@ export class AuthGoogleService {
     return this.oauthService.getIdentityClaims();
   }
 
+  /** Return the raw Google access token */
+  getAccessToken(): string {
+    return this.oauthService.getAccessToken();
+  }
+
 }

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthGoogleService } from '../auth-google.service';
+import { AuthService } from '../modules/auth/services/auth.service';
 import { PermissionService } from '../modules/auth/services/permission.service';
 
 @Component({
@@ -12,6 +13,7 @@ export class MainComponent implements OnInit {
 
   constructor(
     private authGoogleService: AuthGoogleService,
+    private authService: AuthService,
     private permissionService: PermissionService,
     private router: Router
   ) { }
@@ -19,10 +21,17 @@ export class MainComponent implements OnInit {
   ngOnInit(): void {
     const stored = this.authGoogleService.storeCredentials();
     if (stored) {
-      this.permissionService.loadUserPermissions().subscribe(
-        () => this.router.navigate(['/dashboard']),
-        () => this.router.navigate(['/dashboard'])
-      );
+      const token = this.authGoogleService.getAccessToken();
+      const profile = this.authGoogleService.getProfile();
+      this.authService.loginWithGoogle(token, profile).subscribe({
+        next: () => {
+          this.permissionService.loadUserPermissions().subscribe(
+            () => this.router.navigate(['/dashboard']),
+            () => this.router.navigate(['/dashboard'])
+          );
+        },
+        error: () => this.router.navigate(['/auth/login'])
+      });
     } else {
       this.router.navigate(['/auth/login']);
     }

--- a/src/app/modules/auth/services/auth.service.ts
+++ b/src/app/modules/auth/services/auth.service.ts
@@ -109,6 +109,24 @@ export class AuthService implements OnDestroy {
     );
   }
 
+  /**
+   * Authenticate or register a user using a Google access token
+   * and optional profile information returned by Google.
+   */
+  loginWithGoogle(token: string, profile: any): Observable<any> {
+    this.isLoadingSubject.next(true);
+    return this.http
+      .post(`${URL_SERVICIOS}/auth/google`, { token, profile })
+      .pipe(
+        map((auth: any) => this.setAuthFromLocalStorage(auth)),
+        catchError((err) => {
+          console.error('err', err);
+          return of(undefined);
+        }),
+        finalize(() => this.isLoadingSubject.next(false))
+      );
+  }
+
   forgotPassword(email: string): Observable<boolean> {
     this.isLoadingSubject.next(true);
     return this.authHttpService


### PR DESCRIPTION
## Summary
- add `loginWithGoogle` API call in `AuthService`
- expose method to read Google access token
- handle Google login by registering with backend in `MainComponent`

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a87bf2a88322864860f6d8b182e3