### PR TITLE
Integrate Google ID token with backend

### DIFF
--- a/src/app/auth-google.service.ts
+++ b/src/app/auth-google.service.ts
@@ -39,6 +39,7 @@ export class AuthGoogleService {
       if (profile) {
         localStorage.setItem('user', JSON.stringify(profile));
         localStorage.setItem('token', this.oauthService.getAccessToken());
+        localStorage.setItem('id_token', this.oauthService.getIdToken());
         return true;
       }
     }
@@ -54,6 +55,16 @@ export class AuthGoogleService {
 
   getProfile() {
     return this.oauthService.getIdentityClaims();
+  }
+
+  /** Return the raw Google access token */
+  getAccessToken(): string {
+    return this.oauthService.getAccessToken();
+  }
+
+  /** Return the Google ID token */
+  getIdToken(): string {
+    return this.oauthService.getIdToken();
   }
 
 }

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthGoogleService } from '../auth-google.service';
+import { AuthService } from '../modules/auth/services/auth.service';
 import { PermissionService } from '../modules/auth/services/permission.service';
 
 @Component({
@@ -12,6 +13,7 @@ export class MainComponent implements OnInit {
 
   constructor(
     private authGoogleService: AuthGoogleService,
+    private authService: AuthService,
     private permissionService: PermissionService,
     private router: Router
   ) { }
@@ -19,10 +21,16 @@ export class MainComponent implements OnInit {
   ngOnInit(): void {
     const stored = this.authGoogleService.storeCredentials();
     if (stored) {
-      this.permissionService.loadUserPermissions().subscribe(
-        () => this.router.navigate(['/dashboard']),
-        () => this.router.navigate(['/dashboard'])
-      );
+      const idToken = this.authGoogleService.getIdToken();
+      this.authService.loginWithGoogle(idToken).subscribe({
+        next: () => {
+          this.permissionService.loadUserPermissions().subscribe(
+            () => this.router.navigate(['/dashboard']),
+            () => this.router.navigate(['/dashboard'])
+          );
+        },
+        error: () => this.router.navigate(['/auth/login'])
+      });
     } else {
       this.router.navigate(['/auth/login']);
     }

--- a/src/app/modules/auth/services/auth.service.ts
+++ b/src/app/modules/auth/services/auth.service.ts
@@ -109,6 +109,23 @@ export class AuthService implements OnDestroy {
     );
   }
 
+  /**
+   * Authenticate or register a user using a Google ID token.
+   */
+  loginWithGoogle(idToken: string): Observable<any> {
+    this.isLoadingSubject.next(true);
+    return this.http
+      .post(`${URL_SERVICIOS}/auth/google`, { id_token: idToken })
+      .pipe(
+        map((auth: any) => this.setAuthFromLocalStorage(auth)),
+        catchError((err) => {
+          console.error('err', err);
+          return of(undefined);
+        }),
+        finalize(() => this.isLoadingSubject.next(false))
+      );
+  }
+
   forgotPassword(email: string): Observable<boolean> {
     this.isLoadingSubject.next(true);
     return this.authHttpService


### PR DESCRIPTION
## Summary
- store Google ID token in local storage
- expose `getIdToken` helper
- send ID token only to `/auth/google`
- call updated API from `MainComponent`

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a87bf2a88322864860f6d8b182e3