### PR TITLE
Fix FormData headers in product service

### DIFF
--- a/src/app/modules/products/service/product.service.ts
+++ b/src/app/modules/products/service/product.service.ts
@@ -30,25 +30,30 @@ export class ProductService {
   }
   
   // Método para crear encabezados HTTP con el token y permisos
-  private getHeaders(): HttpHeaders {
+  private getHeaders(isFormData: boolean = false): HttpHeaders {
     // Obtener el token de manera segura
     const token = this.authservice.token || localStorage.getItem('token');
     
     if (!token) {
       console.warn('No hay token disponible');
-      return new HttpHeaders({
-        'Content-Type': 'application/json'
-      });
+      const headersData: any = {};
+      if (!isFormData) {
+        headersData['Content-Type'] = 'application/json';
+      }
+      return new HttpHeaders(headersData);
     }
     
     // Verificar si el servicio está listo
     if (!this.isServiceReady()) {
       console.warn('Servicio no está completamente inicializado, usando valores por defecto');
-      return new HttpHeaders({
+      const headersData: any = {
         'Authorization': 'Bearer ' + token,
-        'X-User-Permission': 'manage-own-products',
-        'Content-Type': 'application/json'
-      });
+        'X-User-Permission': 'manage-own-products'
+      };
+      if (!isFormData) {
+        headersData['Content-Type'] = 'application/json';
+      }
+      return new HttpHeaders(headersData);
     }
     
     // Determinar el permiso correcto a usar basado en los permisos actuales
@@ -66,11 +71,14 @@ export class ProductService {
     }
     
     // Crear headers con el permiso adecuado
-    const headers = new HttpHeaders({
+    const headersData: any = {
       'Authorization': 'Bearer ' + token,
-      'X-User-Permission': permissionToUse,
-      'Content-Type': 'application/json'
-    });
+      'X-User-Permission': permissionToUse
+    };
+    if (!isFormData) {
+      headersData['Content-Type'] = 'application/json';
+    }
+    const headers = new HttpHeaders(headersData);
     
     // Log seguro del token (solo primeros caracteres)
     const tokenPreview = token && token.length > 10 ? token.substring(0, 10) + '...' : 'token_corto';
@@ -128,7 +136,7 @@ export class ProductService {
 
   createProducts(data: any) {
     this.isLoadingSubject.next(true);
-    let headers = this.getHeaders();
+    let headers = this.getHeaders(true);
     let URL = URL_SERVICIOS + "/admin/products"; 
     
     console.log('Intentando crear producto con permiso:', headers.get('X-User-Permission'));
@@ -164,7 +172,7 @@ export class ProductService {
 
   updateProducts(product_id: string, data: any) {
     this.isLoadingSubject.next(true);
-    let headers = this.getHeaders();
+    let headers = this.getHeaders(true);
     let URL = URL_SERVICIOS + "/admin/products/" + product_id; 
     
     return this.http.post(URL, data, { headers: headers }).pipe(
@@ -192,7 +200,7 @@ export class ProductService {
 
   imagenAdd(data: any) {
     this.isLoadingSubject.next(true);
-    let headers = this.getHeaders();
+    let headers = this.getHeaders(true);
     let URL = URL_SERVICIOS + "/admin/products/imagens"; 
     
     return this.http.post(URL, data, { headers: headers }).pipe(


### PR DESCRIPTION
## Summary
- handle `Content-Type` header correctly for FormData
- use the new header method for creating, updating and adding product images

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b67735b3883229ab41abe666e7384