### PR TITLE
Product creation limit enforcement

### DIFF
--- a/src/app/_metronic/shared/shared.module.ts
+++ b/src/app/_metronic/shared/shared.module.ts
@@ -1,16 +1,19 @@
 import {NgModule} from '@angular/core';
 import {KeeniconComponent} from './keenicon/keenicon.component';
 import {CommonModule} from "@angular/common";
+import { AlertComponent } from '../shared/components/alert/alert.component';
 
 @NgModule({
   declarations: [
-    KeeniconComponent
+    KeeniconComponent,
+    AlertComponent
   ],
   imports: [
     CommonModule,
   ],
   exports: [
-    KeeniconComponent
+    KeeniconComponent,
+    AlertComponent
   ]
 })
 export class SharedModule {

--- a/src/app/core/guards/product-limit.guard.ts
+++ b/src/app/core/guards/product-limit.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, Router, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { ProductLimitService } from 'src/app/modules/products/service/product-limit.service';
+import { map } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class ProductLimitGuard  {
+  constructor(private productLimit: ProductLimitService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return this.productLimit.canCreateProduct().pipe(
+      map(canCreate => {
+        if (canCreate) {
+          return true;
+        }
+        return this.router.parseUrl('/products/list');
+      })
+    );
+  }
+}

--- a/src/app/modules/products/create-product/create-product.component.html
+++ b/src/app/modules/products/create-product/create-product.component.html
@@ -157,7 +157,10 @@
         </div>
         <div class="row mb-6">
             <div class="col-3">
-                <button class="btn btn-primary" (click)="save()">Guardar</button>
+                <button class="btn btn-primary" (click)="save()" [disabled]="!canCreate">Guardar</button>
+            </div>
+            <div class="col-9" *ngIf="!canCreate">
+                <app-alert [message]="limitMessage"></app-alert>
             </div>
         </div>
 

--- a/src/app/modules/products/create-product/create-product.component.spec.ts
+++ b/src/app/modules/products/create-product/create-product.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+import { AlertComponent } from 'src/app/shared/components/alert/alert.component';
+import { ProductLimitService } from '../service/product-limit.service';
+import { CreateProductComponent } from './create-product.component';
+import { ProductService } from '../service/product.service';
+import { ToastrService } from 'ngx-toastr';
+
+class LimitStub {
+  canCreate = true;
+  canCreateProduct() { return of(this.canCreate); }
+}
+
+describe('CreateProductComponent UI', () => {
+  let component: CreateProductComponent;
+  let fixture: ComponentFixture<CreateProductComponent>;
+  let limit: LimitStub;
+
+  beforeEach(() => {
+    limit = new LimitStub();
+    TestBed.configureTestingModule({
+      declarations: [CreateProductComponent, AlertComponent],
+      imports: [FormsModule],
+      providers: [
+        { provide: ProductLimitService, useValue: limit },
+        { provide: ProductService, useValue: { configAll: () => of(null) } },
+        { provide: ToastrService, useValue: { error: () => {}, success: () => {} } }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(CreateProductComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should enable button when client has less than 3', () => {
+    limit.canCreate = true;
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeFalse();
+  });
+
+  it('should disable button and show message when client has 3 or more', () => {
+    limit.canCreate = false;
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeTrue();
+    expect(fixture.nativeElement.textContent).toContain('Has alcanzado el límite de 3 productos.');
+  });
+
+  it('admin should enable button always', () => {
+    limit.canCreate = true;
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeFalse();
+  });
+});

--- a/src/app/modules/products/create-product/create-product.component.ts
+++ b/src/app/modules/products/create-product/create-product.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { ProductService } from '../service/product.service';
 import { ToastrService } from 'ngx-toastr';
 import { IDropdownSettings } from 'ng-multiselect-dropdown';
+import { ProductLimitService } from '../service/product-limit.service';
 
 @Component({
   selector: 'app-create-product',
@@ -38,6 +39,9 @@ export class CreateProductComponent {
   word:string = '';
 
   isShowMultiselect:Boolean = false;
+
+  canCreate = true;
+  limitMessage = '';
   
   // Array de tipos de archivo de imagen permitidos
   private allowedImageTypes: string[] = [
@@ -52,8 +56,9 @@ export class CreateProductComponent {
   constructor(
     public productService: ProductService,
     private toastr: ToastrService,
+    private productLimit: ProductLimitService,
   ) {
-    
+
   }
 
   ngOnInit(): void {
@@ -78,6 +83,12 @@ export class CreateProductComponent {
       allowSearchFilter: true
     };
     this.configAll();
+    this.productLimit.canCreateProduct().subscribe(can => {
+      this.canCreate = can;
+      if (!can) {
+        this.limitMessage = 'Has alcanzado el límite de 3 productos.';
+      }
+    });
   }
 
   // Función para generar SKU automáticamente basado en el título
@@ -257,6 +268,10 @@ export class CreateProductComponent {
   }
 
   save(){
+    if(!this.canCreate){
+      this.toastr.error('Límite alcanzado', this.limitMessage);
+      return;
+    }
     console.log("Verificando campos del formulario...");
     
     // Comprobamos cada campo individualmente y mostramos su estado

--- a/src/app/modules/products/products-routing.module.ts
+++ b/src/app/modules/products/products-routing.module.ts
@@ -6,6 +6,7 @@ import { LitsProductsComponent } from './lits-products/lits-products.component';
 import { EditProductComponent } from './edit-product/edit-product.component';
 import { CreateVariationSpecificationsComponent } from './attributes/create-variation-specifications/create-variation-specifications.component';
 import { PermissionGuard } from 'src/app/core/guards/permission.guard';
+import { ProductLimitGuard } from 'src/app/core/guards/product-limit.guard';
 
 const routes: Routes = [
   {
@@ -15,7 +16,7 @@ const routes: Routes = [
       {
         path: 'register',
         component: CreateProductComponent,
-        canActivate: [PermissionGuard],
+        canActivate: [PermissionGuard, ProductLimitGuard],
         data: { permission: 'manage-own-products' }
       },
       {

--- a/src/app/modules/products/products.module.ts
+++ b/src/app/modules/products/products.module.ts
@@ -20,6 +20,7 @@ import { DeleteVariationSpecificationsComponent } from './attributes/delete-vari
 import { CreateAnidadoVariationsComponent } from './attributes/create-anidado-variations/create-anidado-variations.component';
 import { EditAnidadoVariationsComponent } from './attributes/edit-anidado-variations/edit-anidado-variations.component';
 import { DeleteAnidadoVariationsComponent } from './attributes/delete-anidado-variations/delete-anidado-variations.component';
+import { SharedModule } from '../../_metronic/shared/shared.module';
 
 @NgModule({
   declarations: [
@@ -48,7 +49,8 @@ import { DeleteAnidadoVariationsComponent } from './attributes/delete-anidado-va
     NgbModalModule,
     NgbPaginationModule,
     CKEditorModule,
-    NgMultiSelectDropDownModule.forRoot()
+    NgMultiSelectDropDownModule.forRoot(),
+    SharedModule
   ]
 })
 export class ProductsModule { }

--- a/src/app/modules/products/service/product-limit.service.spec.ts
+++ b/src/app/modules/products/service/product-limit.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ProductLimitService } from './product-limit.service';
+import { PermissionService } from 'src/app/modules/auth/services/permission.service';
+import { ProductService } from './product.service';
+
+class PermissionStub {
+  admin = false;
+  hasRole(role: string) { return role === 'Admin' && this.admin; }
+}
+
+class ProductStub {
+  response = { count: 0 };
+  countMyProducts() { return of(this.response); }
+}
+
+describe('ProductLimitService', () => {
+  let service: ProductLimitService;
+  let permission: PermissionStub;
+  let product: ProductStub;
+
+  beforeEach(() => {
+    permission = new PermissionStub();
+    product = new ProductStub();
+    TestBed.configureTestingModule({
+      providers: [
+        ProductLimitService,
+        { provide: PermissionService, useValue: permission },
+        { provide: ProductService, useValue: product }
+      ]
+    });
+    service = TestBed.inject(ProductLimitService);
+  });
+
+  it('should allow admin always', (done) => {
+    permission.admin = true;
+    service.canCreateProduct().subscribe(val => {
+      expect(val).toBeTrue();
+      done();
+    });
+  });
+
+  it('should allow when user has less than 3 products', (done) => {
+    product.response = { count: 2 };
+    service.canCreateProduct().subscribe(val => {
+      expect(val).toBeTrue();
+      done();
+    });
+  });
+
+  it('should block when user has 3 or more products', (done) => {
+    product.response = { count: 3 };
+    service.canCreateProduct().subscribe(val => {
+      expect(val).toBeFalse();
+      done();
+    });
+  });
+});

--- a/src/app/modules/products/service/product-limit.service.ts
+++ b/src/app/modules/products/service/product-limit.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { PermissionService } from 'src/app/modules/auth/services/permission.service';
+import { ProductService } from './product.service';
+
+@Injectable({ providedIn: 'root' })
+export class ProductLimitService {
+  constructor(
+    private permissionService: PermissionService,
+    private productService: ProductService
+  ) {}
+
+  canCreateProduct(): Observable<boolean> {
+    // Si es admin siempre puede crear
+    if (this.permissionService.hasRole('Admin')) {
+      return of(true);
+    }
+
+    return this.productService.countMyProducts().pipe(
+      map(resp => resp.count < 3),
+      catchError(() => of(true))
+    );
+  }
+}

--- a/src/app/modules/products/service/product.service.ts
+++ b/src/app/modules/products/service/product.service.ts
@@ -215,7 +215,7 @@ export class ProductService {
   deleteImageProduct(imagen_id: string) {
     this.isLoadingSubject.next(true);
     let headers = this.getHeaders();
-    let URL = URL_SERVICIOS + "/admin/products/imagens/" + imagen_id; 
+    let URL = URL_SERVICIOS + "/admin/products/imagens/" + imagen_id;
     
     return this.http.delete(URL, { headers: headers }).pipe(
       tap(response => {
@@ -224,5 +224,11 @@ export class ProductService {
       catchError(this.handleError),
       finalize(() => this.isLoadingSubject.next(false))
     );
+  }
+
+  countMyProducts() {
+    let headers = this.getHeaders();
+    let URL = URL_SERVICIOS + '/admin/products/user-count';
+    return this.http.get<{count:number}>(URL, { headers });
   }
 }

--- a/src/app/pages/user/user-listing/user-listing.component.spec.ts
+++ b/src/app/pages/user/user-listing/user-listing.component.spec.ts
@@ -10,7 +10,7 @@ describe('UserListingComponent', () => {
     TestBed.configureTestingModule({
       declarations: [UserListingComponent]
     });
-    fixture = TestBed.createComponent(v);
+    fixture = TestBed.createComponent(UserListingComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -1,0 +1,3 @@
+<div class="alert alert-danger" role="alert">
+  {{ message }}
+</div>

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -1,0 +1,9 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html'
+})
+export class AlertComponent {
+  @Input() message = '';
+}


### PR DESCRIPTION
## Summary
- add ProductLimitService and guard
- integrate limit check in create product UI
- show AlertComponent when limit exceeded
- update routing to use the new guard
- export AlertComponent via shared module
- add unit tests

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684b7fb279e8832286cb8b9d2bbf3bb0